### PR TITLE
サイドバーにグループチャットの文章を表示する

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -3,4 +3,12 @@ class Group < ApplicationRecord
   has_many :users, through: :group_users
   has_many :messages
   validates :name, presence: true
+
+   def show_last_message
+    if (last_message = messages.last).present?
+      last_message.content? ? last_message.content : '画像が投稿されています'
+    else
+      'まだメッセージはありません。'
+    end
+  end
 end

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -3,7 +3,7 @@
 .contents-head
   .contents-head__group
     .group__groupName
-      sampleグループ
+      = @group.name
     =link_to 'Edit', "edit", :class => "group__edit"
   .contents-head__members
     Members: Natsumi

--- a/app/views/shared/_groups.html.haml
+++ b/app/views/shared/_groups.html.haml
@@ -14,4 +14,4 @@
             .items__name
               = group.name
             .items__message
-              まだメッセージはありません。
+              = group.show_last_message


### PR DESCRIPTION
# WHAT
サイドバーにグループチャットの最後の文を表示する機能を追加

# WHY
ユーザーが見やすくするため。